### PR TITLE
DOCSP-4690: Add new endpoint for accepting yes/no feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple web feedback server.
 
 ## Local Development
 
-Install local develop and default packages:
+Install all development dependencies:
 ```shell
 pipenv install --dev
 ```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,27 @@ Deluge
 ======
 
 A simple web feedback server.
+
+## Local Development
+
+Install local develop and default packages:
+```shell
+pipenv install --dev
+```
+
+Ensure you are running a local `mongod` instance on default port 27017. To run the Deluge server:
+```shell
+CONNECTION_STRING="mongodb://localhost:27017" pipenv run python3 -m deluge
+```
+
+You can now make requests to the server at `http://localhost:4000`.
+
+### Troubleshooting
+If starting the server fails, ensure that `ssl=False` in `deluge/application.py` for development purposes.
+
+## Linting
+
+To lint before pushing changes to GitHub:
+```shell
+make lint test
+```


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-4690)] This PR:
- Adds a new server endpoint at `/initial_vote` to collect feedback when user first responds to "Was this page helpful?"
- Writes these initial votes to a collection called `votesInitial`. Each document is saved with fields `page`, `useful`, `ip`, `date`, and `voteId`.
- Adds an (optional) `voteId` field to new documents in the `votes` collection to link initial and feedback votes. This unique identifier is created on the client side. It is optional to prevent failure as the feature is deployed at different times to the different Docs properties.
- Adds documentation for local development.